### PR TITLE
update simple draw for case when weight sum is 0, presently this crashes

### DIFF
--- a/synthpop/draw.py
+++ b/synthpop/draw.py
@@ -28,8 +28,12 @@ def simple_draw(num, weights, index):
         Array of indexes drawn based on weights.
 
     """
-    p = weights / weights.sum()
-    return np.random.choice(index, size=num, p=p, replace=True)
+    w_sum = weights.sum()
+    if w_sum != 0:
+        p = weights / weights.sum()
+        return np.random.choice(index, size=num, p=p, replace=True)
+    else:
+        return np.random.choice(index, size=num)
 
 
 def _draw_indexes(num, fac, weights):


### PR DESCRIPTION
I'm not sure exactly how this happens, but in some cases, each household sample within a given category has a weight of 0, which then crashes the synthesis during draw_simple method. This tweak will randomly choose among the households and thus allow the synthesis to finish. 

It is probably worthwhile to look into how the weight sum comes to be 0, and it might be a good idea to log the issue. 
